### PR TITLE
Tune `htmlWhitespaceSensitivity` option in prettier settings

### DIFF
--- a/packages/eslint-config-ts/index.js
+++ b/packages/eslint-config-ts/index.js
@@ -24,7 +24,8 @@ module.exports = {
         semi: false,
         singleQuote: true,
         jsxSingleQuote: true,
-        trailingComma: 'none'
+        trailingComma: 'none',
+        htmlWhitespaceSensitivity: 'ignore' // https://prettier.io/blog/2018/11/07/1.15.0.html#whitespace-sensitive-formatting
       }
     ]
   }


### PR DESCRIPTION
### What does this PR do?
By following the nature of our projects, we decided to tweak default Prettier settings and ignore white space sensitivity in order to have a more readable code.
So that
```
<a href="https://prettier.io/">Prettier is an opinionated code formatter.</a>
```
will always become
```
<a href="https://prettier.io/">
   Prettier is an opinionated code formatted.
</a>
```

In case we'll decide to revert this change and apply a different strategy please check always the following document 
 https://prettier.io/blog/2018/11/07/1.15.0.html#whitespace-sensitive-formatting
