### PR TITLE
Add missing dependencies for `eslint-config-ts-react` package

### DIFF
--- a/packages/eslint-config-ts-react/package.json
+++ b/packages/eslint-config-ts-react/package.json
@@ -32,6 +32,8 @@
   },
   "dependencies": {
     "@commercelayer/eslint-config-ts": "workspace:^0.1.2",
+    "@typescript-eslint/eslint-plugin": "^5.38.0",
+    "@typescript-eslint/parser": "^5.38.0",
     "eslint-config-standard-jsx": "^11.0.0",
     "eslint-plugin-react": "^7.31.8"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,12 +38,16 @@ importers:
   packages/eslint-config-ts-react:
     specifiers:
       '@commercelayer/eslint-config-ts': workspace:^0.1.2
+      '@typescript-eslint/eslint-plugin': ^5.38.0
+      '@typescript-eslint/parser': ^5.38.0
       eslint: ^8.24.0
       eslint-config-standard-jsx: ^11.0.0
       eslint-plugin-react: ^7.31.8
       typescript: ^4.8.3
     dependencies:
       '@commercelayer/eslint-config-ts': link:../eslint-config-ts
+      '@typescript-eslint/eslint-plugin': 5.38.0_4gkcvl6qsi23tqqawfqgcwtp54
+      '@typescript-eslint/parser': 5.38.0_7ilbxdl5iguzcjriqqcg2m5cku
       eslint-config-standard-jsx: 11.0.0_fuvt5lq3jtq3jxmnxgu6za4znm
       eslint-plugin-react: 7.31.8_eslint@8.24.0
     devDependencies:
@@ -1875,8 +1879,8 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
     dependencies:
-      is-text-path: 1.0.1
       JSONStream: 1.3.5
+      is-text-path: 1.0.1
       lodash: 4.17.21
       meow: 8.1.2
       split2: 3.2.2


### PR DESCRIPTION
### What does this PR do?
When `@commercelayer/eslint-config-ts-react` is installed as standalone, it needs to include
```
@typescript-eslint/eslint-plugin
@typescript-eslint/parser
```
This is because (depending on your project settings) it might not be resolved within the base package (`@commercelayer/eslint-config`) 