### PR TITLE
Add new eslint-config rule for `@typescript-eslint/switch-exhaustiveness-check`

### DIFF
--- a/packages/eslint-config-ts-react/index.js
+++ b/packages/eslint-config-ts-react/index.js
@@ -1,10 +1,6 @@
 module.exports = {
-  env: {
-    browser: true,
-    es2021: true
-  },
   extends: [
-    'standard-with-typescript', // all standard and ts-standard rules from the official pkg
+    '@commercelayer/eslint-config-ts', // our base config
     'standard-jsx', // set of rules defined for react and jsx from the official pkg
     'prettier' // disable other formatting rules
   ],
@@ -22,19 +18,6 @@ module.exports = {
       version: 'detect'
     }
   },
-  plugins: [
-    'prettier' // allow to use prettier/prettier as eslint rules
-  ],
-  rules: {
-    // we need to tell prettier to use same formatting rules as required by standard
-    'prettier/prettier': [
-      'error',
-      {
-        semi: false,
-        singleQuote: true,
-        jsxSingleQuote: true,
-        trailingComma: 'none'
-      }
-    ]
-  }
+  plugins: [],
+  rules: {}
 }

--- a/packages/eslint-config-ts/index.js
+++ b/packages/eslint-config-ts/index.js
@@ -27,6 +27,7 @@ module.exports = {
         trailingComma: 'none',
         htmlWhitespaceSensitivity: 'ignore' // https://prettier.io/blog/2018/11/07/1.15.0.html#whitespace-sensitive-formatting
       }
-    ]
+    ],
+    '@typescript-eslint/switch-exhaustiveness-check': 'error'
   }
 }


### PR DESCRIPTION
### What does this PR do?
We decided to improve our base config package to also check for the following rule: 
https://typescript-eslint.io/rules/switch-exhaustiveness-check/

At the same time `eslint-config-ts-react` has been improved to directly extend our `eslint-config-ts` package instead of replicate same rules