### PR TITLE
Remove `console.log`

### DIFF
--- a/packages/organization-config/src/index.ts
+++ b/packages/organization-config/src/index.ts
@@ -138,7 +138,6 @@ export function getConfig({
   params
 }: GetConfigProps): DefaultConfig | null {
   if (jsonConfig?.mfe == null) {
-    console.warn('No configuration found.')
     return null
   }
 


### PR DESCRIPTION

## What I did

I removed the `console.log` to avoid "spam" in the browser dev console when configuration is not defined.
