### PR TITLE
Define `DefaultMfeConfig` as non nullable

### DIFF
--- a/packages/organization-config/src/getMfeConfig.ts
+++ b/packages/organization-config/src/getMfeConfig.ts
@@ -57,8 +57,8 @@ export type MfeConfigs = NonNullable<
 >
 
 export type DefaultMfeConfig = NonNullable<
-  ValidConfigForOrganizationsInCommerceLayer['mfe']
->['default']
+  NonNullable<ValidConfigForOrganizationsInCommerceLayer['mfe']>['default']
+>
 
 /**
  * Retrieves and merges the default organization configuration with market-specific overrides based on the provided market identifier.


### PR DESCRIPTION

## What I did

This pull request includes a change to the `getMfeConfig.ts` file to improve type safety and clarity in the `DefaultMfeConfig` type definition.

Improvements to type safety and clarity:

* [`packages/organization-config/src/getMfeConfig.ts`](diffhunk://#diff-c2b7610fde125211202cf5c7eaa98f04231b8e5dc117ee62a881cde3d2caa8b4L60-R61): Modified the `DefaultMfeConfig` type definition to ensure non-nullability by wrapping the `ValidConfigForOrganizationsInCommerceLayer['mfe']` type in a `NonNullable` utility type.

## How to test

<!-- Please include the steps to test your changes here -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [ ] You are **NOT** deprecating/removing a feature.
