### PR TITLE
Add option to hide item codes and returns on MFEs

### DIFF
--- a/packages/organization-config/src/getMfeConfig.test.ts
+++ b/packages/organization-config/src/getMfeConfig.test.ts
@@ -216,6 +216,68 @@ describe("getMfeConfig function", () => {
     expect(config?.language).toBe("en-US")
   })
 
+  it("should handle hide item code on checkout", () => {
+    const config = getMfeConfig({
+      jsonConfig: {
+        mfe: {
+          default: {
+            checkout: {
+              hide_item_codes: true,
+            },
+          },
+        },
+      },
+    })
+    expect(config?.checkout?.hide_item_codes).toBe(true)
+  })
+
+  it("should handle hide item code on cart", () => {
+    const config = getMfeConfig({
+      jsonConfig: {
+        mfe: {
+          default: {
+            cart: {
+              hide_item_codes: true,
+            },
+          },
+        },
+      },
+    })
+    expect(config?.cart?.hide_item_codes).toBe(true)
+  })
+
+  it("should handle hide item code on microstore", () => {
+    const config = getMfeConfig({
+      jsonConfig: {
+        mfe: {
+          default: {
+            microstore: {
+              hide_item_codes: true,
+            },
+          },
+        },
+      },
+    })
+    expect(config?.microstore?.hide_item_codes).toBe(true)
+  })
+
+  it("should handle hide item code on my-account and hide returns", () => {
+    const config = getMfeConfig({
+      jsonConfig: {
+        mfe: {
+          default: {
+            my_account: {
+              hide_item_codes: true,
+              hide_returns: true,
+            },
+          },
+        },
+      },
+    })
+    expect(config?.my_account?.hide_item_codes).toBe(true)
+    expect(config?.my_account?.hide_returns).toBe(true)
+  })
+
   it("should handle language as market override", () => {
     const config = getMfeConfig({
       jsonConfig: {

--- a/packages/organization-config/src/schema/types.ts
+++ b/packages/organization-config/src/schema/types.ts
@@ -88,6 +88,7 @@ export interface MfeConfig {
    * Settings for the Checkout micro front end.
    */
   checkout?: {
+    hide_item_codes?: boolean
     thankyou_page?: Url
     optional_billing_info?: boolean
     billing_countries?: StateCountry
@@ -105,6 +106,25 @@ export interface MfeConfig {
     shipping_states?: {
       [k: string]: StateCountry3
     }
+  }
+  /**
+   * Settings for the Cart micro front end.
+   */
+  cart?: {
+    hide_item_codes?: boolean
+  }
+  /**
+   * Settings for the microstore micro front end.
+   */
+  microstore?: {
+    hide_item_codes?: boolean
+  }
+  /**
+   * Settings for the my-account micro front end.
+   */
+  my_account?: {
+    hide_item_codes?: boolean
+    hide_returns?: boolean
   }
   /**
    * Checkout internal links settings.


### PR DESCRIPTION
Closes #53 

## What I did

This PR will add the option to hide item codes on MFEs and hide returns on my account.
## How to test

<!-- Please include the steps to test your changes here -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [x] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
